### PR TITLE
notify now works on linux w/ notify-send

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { execa } from "execa";
 
+const PLATFORM = process.platform;
 const DEFAULT_DESCRIPTION = "Your task finished";
 const DEFAULT_TITLE = "Done";
 
@@ -10,10 +11,19 @@ type NotifyOptions = {
 const notify = async (
   title: string = DEFAULT_TITLE,
   description: string = DEFAULT_DESCRIPTION,
-  options: NotifyOptions,
+  options: NotifyOptions
 ) => {
+  if (PLATFORM === "linux") {
+    return await execa(`notify-send`, [
+      `-a`,
+      `NOTIFY-ME`,
+      `${title} ${description}`,
+    ]);
+  }
   await execa(`osascript`, [
-    `-e display notification "${description}" with title "${title}" ${options.sound ? 'sound name "Tink"' : ""}`,
+    `-e display notification "${description}" with title "${title}" ${
+      options.sound ? 'sound name "Tink"' : ""
+    }`,
   ]);
 };
 


### PR DESCRIPTION
closes #1 Linux Support

Commands have been designed to seamlessly integrate with the most prevalent Linux notification daemon. A verification step has been added to determine the operating system using `const PLATFORM = process.platform`. Following this logic, a notification is dispatched to `notify-send`, which stands as the predominant notification daemon for Linux.
